### PR TITLE
Added stream-indexer service

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "deploy-and-graph": "yarn deploy && yarn graph-ship-local",
     "theme": "yarn workspace @scaffold-eth/react-app theme",
     "watch-theme": "yarn workspace @scaffold-eth/react-app watch",
-    "backend": "cd packages/backend && nodemon --ignore 'local_database/*.json' index"
+    "backend": "cd packages/backend && nodemon --ignore 'local_database/*.json' index",
+    "stream-indexer": "cd packages/backend/services/stream-indexer && nodemon --ignore 'local_database/*.json' index"
   },
   "workspaces": {
     "packages": [

--- a/packages/backend/local_database/seed.json
+++ b/packages/backend/local_database/seed.json
@@ -14,6 +14,13 @@
       }
     }
   },
+  "streams": [
+    {
+      "streamAddress": "0x86c6C2c9699bE74278E0d73065fF12249221Bd30",
+      "builderAddress": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+      "lastIndexedBlock": 0
+    }
+  ],
   "builds": [
     {
       "name": "🎟 Simple NFT Example",

--- a/packages/backend/services/db/db.js
+++ b/packages/backend/services/db/db.js
@@ -48,6 +48,12 @@ const findAllUsers = db.findAllUsers;
  */
 const findUserByAddress = db.findUserByAddress;
 
+// --- Streams
+/**
+ * Returns a list of payment streams.
+ */
+const findAllStreams = db.findAllStreams;
+
 // --- Events
 /**
  *
@@ -133,6 +139,8 @@ module.exports = {
   updateUser,
   findAllUsers,
   findUserByAddress,
+
+  findAllStreams,
 
   createEvent,
   findAllEvents,

--- a/packages/backend/services/db/dbLocal.js
+++ b/packages/backend/services/db/dbLocal.js
@@ -8,12 +8,12 @@ require("dotenv").config();
 const fs = require("fs");
 const { getProp } = require("../../utils/object");
 
-console.log("using local db");
-
-const DATABASE_PATH = "./local_database/local_db.json";
-const SEED_PATH = "./local_database/seed.json";
+const DATABASE_PATH = process.env.DATABASE_PATH ? process.env.DATABASE_PATH : "./local_database/local_db.json";
+const SEED_PATH = process.env.SEED_PATH ? process.env.SEED_PATH : "./local_database/seed.json";
 const databaseSeed = JSON.parse(fs.readFileSync(SEED_PATH, "utf8"));
 const emptyTestDatabase = { version: 0, users: {}, builds: {}, events: [] };
+
+console.log(`using local db: ${DATABASE_PATH}`);
 
 if (!fs.existsSync(DATABASE_PATH)) {
   // Seed the local database if empty.
@@ -89,6 +89,11 @@ const findAllUsers = () => {
   return Object.entries(database.users).map(([id, userData]) => ({ id, ...userData }));
 };
 
+// --- Streams
+const findAllStreams = () => {
+  return Object.entries(database.streams).map(([id, streamData]) => ({ id, ...streamData }));
+};
+
 // --- Events
 const createEvent = event => {
   database.events.push(event);
@@ -156,6 +161,8 @@ module.exports = {
   updateUser,
   findAllUsers,
   findUserByAddress,
+
+  findAllStreams,
 
   createEvent,
   findAllEvents,

--- a/packages/backend/services/stream-indexer/app.yaml
+++ b/packages/backend/services/stream-indexer/app.yaml
@@ -1,0 +1,6 @@
+# Google app engine deployment
+runtime: nodejs14
+env: standard
+entrypoint: node index.js
+env_variables:
+  RPC_URL=https://mainnet.infura.io/v3/XXX

--- a/packages/backend/services/stream-indexer/env.sample
+++ b/packages/backend/services/stream-indexer/env.sample
@@ -1,0 +1,4 @@
+#RPC_URL="https://mainnet.infura.io/v3/xxx"
+# Override database path
+#DATABASE_PATH=../../local_database/local_db.json
+#SEED_PATH=../../local_database/seed.json

--- a/packages/backend/services/stream-indexer/index.js
+++ b/packages/backend/services/stream-indexer/index.js
@@ -1,0 +1,167 @@
+require("dotenv").config();
+const ethers = require("ethers");
+const db = require("../db/db");
+
+const SIMPLE_STREAM_ABI = [
+  {
+    inputs: [
+      { internalType: "address payable", name: "_toAddress", type: "address" },
+      { internalType: "uint256", name: "_cap", type: "uint256" },
+      { internalType: "uint256", name: "_frequency", type: "uint256" },
+      { internalType: "bool", name: "_startsFull", type: "bool" },
+    ],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "from", type: "address" },
+      { indexed: false, internalType: "uint256", name: "amount", type: "uint256" },
+      { indexed: false, internalType: "string", name: "reason", type: "string" },
+    ],
+    name: "Deposit",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "to", type: "address" },
+      { indexed: false, internalType: "uint256", name: "amount", type: "uint256" },
+      { indexed: false, internalType: "string", name: "reason", type: "string" },
+    ],
+    name: "Withdraw",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "cap",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "frequency",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "last",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "streamBalance",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "string", name: "reason", type: "string" }],
+    name: "streamDeposit",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "amount", type: "uint256" },
+      { internalType: "string", name: "reason", type: "string" },
+    ],
+    name: "streamWithdraw",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "toAddress",
+    outputs: [{ internalType: "address payable", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  { stateMutability: "payable", type: "receive" },
+];
+
+/**
+ * Retrieve a list of deposit/withdraw events for the given `streamAddress`.
+ *
+ * @param provider A connected ethersjs provider
+ * @param streamAddress Stream for which events will be received
+ * @param fromBlock Begin searching from this block number
+ * @param toBlock Search up to this block number
+ * @return {Promise<{balance: string, streamAddress, events: {type: string, payload: object}[]}>}
+ */
+const getStreamEvents = async (provider, streamAddress, fromBlock, toBlock) => {
+  const streamContract = new ethers.Contract(streamAddress, SIMPLE_STREAM_ABI, provider);
+  const withdrawFilter = streamContract.filters.Withdraw();
+  withdrawFilter.fromBlock = fromBlock;
+  withdrawFilter.toBlock = toBlock;
+  const withdrawLogs = await provider.getLogs(withdrawFilter);
+  const depositFilter = streamContract.filters.Deposit();
+  depositFilter.fromBlock = fromBlock;
+  depositFilter.toBlock = toBlock;
+  const depositLogs = await provider.getLogs(depositFilter);
+
+  const withdrawEvents = await Promise.all(
+    withdrawLogs.map(async log => {
+      const data = streamContract.interface.parseLog(log);
+      const block = await provider.getBlock(log.blockNumber);
+      return {
+        type: "stream.withdraw",
+        payload: {
+          to: data.args.to,
+          amount: ethers.utils.formatEther(data.args.amount),
+          reason: data.args.reason,
+          block: log.blockNumber,
+          timestamp: block.timestamp,
+          tx: log.transactionHash,
+        },
+      };
+    }),
+  );
+  const depositEvents = await Promise.all(
+    depositLogs.map(async log => {
+      const data = streamContract.interface.parseLog(log);
+      const block = await provider.getBlock(log.blockNumber);
+      return {
+        type: "stream.deposit",
+        payload: {
+          from: data.args.from,
+          amount: ethers.utils.formatEther(data.args.amount),
+          reason: data.args.reason,
+          block: log.blockNumber,
+          timestamp: block.timestamp,
+          tx: log.transactionHash,
+        },
+      };
+    }),
+  );
+
+  return {
+    streamAddress,
+    balance: ethers.utils.formatEther(await provider.getBalance(streamAddress)),
+    events: [...withdrawEvents, ...depositEvents],
+  };
+};
+
+const processStreamEvents = async () => {
+  const provider = new ethers.providers.StaticJsonRpcProvider(process.env.RPC_URL);
+  const streams = db.findAllStreams();
+
+  const currentBlock = await provider.getBlockNumber();
+
+  streams.forEach(stream => {
+    getStreamEvents(provider, stream.streamAddress, stream.lastIndexedBlock, currentBlock).then(result => {
+      console.log(JSON.stringify(result, null, 2));
+      console.log(`Stream ${stream.streamAddress} updated to ${currentBlock}`);
+    });
+  });
+};
+
+processStreamEvents().then(() => {});


### PR DESCRIPTION
- added function to retrieve deposit/withdraw events for a given stream
- added example function which processes all streams stored in the DB (it just prints out the events)
- added `streams` object to db seed, and `dbLocal.js`. Not added to `dbFirebase`.
- added env vars so DB/seed paths can be overridden (required because stream-indexer is executed from a sub-directory of `backend`)
- added untested sample app.yaml

#13 