### PR TITLE
stream component becomes stale

### DIFF
--- a/packages/react-app/pages/_app.js
+++ b/packages/react-app/pages/_app.js
@@ -231,6 +231,7 @@ function MyApp({ Component, pageProps }) {
             />
             <Component
               {...pageProps}
+              key={router.asPath}
               serverUrl={serverUrl}
               mainnetProvider={mainnetProvider}
               address={address}


### PR DESCRIPTION
Navigating from a profile that has a stream, to a profile without a stream, continues to show stream information when it should be empty

https://user-images.githubusercontent.com/122643453/217864237-466724c1-211e-4285-90e4-20faaac6a9ce.mp4