### PR TITLE
Fix: Centering the builder list to prevent misalignment.

### DIFF
--- a/packages/react-app/components/BuilderFunctionList.jsx
+++ b/packages/react-app/components/BuilderFunctionList.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import NextLink from "next/link";
-import { Button, Box, Link, Table, Tbody, Td, Tr } from "@chakra-ui/react";
+import { Button, Box, Link, Table, Tbody, Td, Tr, Center } from "@chakra-ui/react";
 import Address from "./Address";
 import BuilderStreamCell from "./StreamTableCell";
 
@@ -11,25 +11,27 @@ const BuilderFunctionList = ({ builders }) => {
         <Tbody>
           {builders.map(builder => {
             return (
-              <Tr key={builder.id}>
-                <Td>
-                  <NextLink href={`/builders/${builder.id}`} passHref>
-                    <Link as={Link} pos="relative">
-                      <Address address={builder.id} w="12.5" fontSize="16" cachedEns={builder.ens} />
-                    </Link>
-                  </NextLink>
-                </Td>
-                <Td>
-                  <BuilderStreamCell stream={builder.stream} />
-                </Td>
-                <Td display={{ base: "none", md: "block" }}>
-                  <NextLink href={`/builders/${builder.id}`} passHref>
-                    <Button as={Link} size="sm" variant="outline">
-                      View work
-                    </Button>
-                  </NextLink>
-                </Td>
-              </Tr>
+              <Center key={builder.id}>
+                <Tr>
+                  <Td>
+                    <NextLink href={`/builders/${builder.id}`} passHref>
+                      <Link as={Link} pos="relative">
+                        <Address address={builder.id} w="12.5" fontSize="16" cachedEns={builder.ens} />
+                      </Link>
+                    </NextLink>
+                  </Td>
+                  <Td>
+                    <BuilderStreamCell stream={builder.stream} />
+                  </Td>
+                  <Td display={{ base: "none", md: "block" }}>
+                    <NextLink href={`/builders/${builder.id}`} passHref>
+                      <Button as={Link} size="sm" variant="outline">
+                        View work
+                      </Button>
+                    </NextLink>
+                  </Td>
+                </Tr>
+              </Center>
             );
           })}
         </Tbody>


### PR DESCRIPTION
![image](https://github.com/scaffold-eth/buidlguidl-v3/assets/53488449/c716c63b-6987-41b4-8b1e-55a9560c891e)

Noticed the inconsistency with the builder list rows, this is an attempt to fix it.

Couldn't confirm that this fixes the problem as a project ID is required to run the build.

Please check if it helps.  