### PR TITLE
show date under description in build card & build detail page

### DIFF
--- a/packages/react-app/components/BuildCard.jsx
+++ b/packages/react-app/components/BuildCard.jsx
@@ -136,6 +136,10 @@ const BuildCard = ({ build, userProvider, userRole, onUpdate }) => {
           {build.desc}
         </Text>
         <Spacer />
+        <Text fontSize="xs" as="i">
+          {new Date(build.submittedTimestamp).toDateString()}
+        </Text>
+        <Spacer />
         <ButtonGroup mt={3}>
           <NextLink href={`/build/${build.id}`} passHref>
             <Button as={Link} variant="outline" size="sm" isFullWidth>

--- a/packages/react-app/components/BuildDetailHeader.jsx
+++ b/packages/react-app/components/BuildDetailHeader.jsx
@@ -72,10 +72,11 @@ const BuildDetailHeader = ({ build, actionButtons }) => {
             {build.name}
           </Heading>
           <HStack mb={6}>{actionButtons}</HStack>
-          <Text fontSize="lg" mb={6}>
-            {build.desc}
+          <Text fontSize="lg">{build.desc}</Text>
+          <Text fontSize="xs" as="i">
+            {new Date(build.submittedTimestamp).toDateString()}
           </Text>
-          <VStack align="left">
+          <VStack align="left" mt={6}>
             <Builder builderAddress={build.builder} />
             {build?.coBuilders?.map(builderAddress => (
               <Builder builderAddress={builderAddress} key={builderAddress} />


### PR DESCRIPTION
##Context
Currently buidlGuidl does not show date time details for builds and this leads to issue where other user does not know, how fresh that build is. Although build are shown in freshness order on portfolio page but it does not give clear indication how latest those builds are.

#Changes
Added a text field to buildcard and buildDetailsHeader to show time of build submitted under description in italic form.
