### PR TITLE
Add option for users to mark their builds as SE-2 Extension

### DIFF
--- a/packages/backend/routes/builds.js
+++ b/packages/backend/routes/builds.js
@@ -68,7 +68,7 @@ router.post("/", withRole("builder"), async (req, res) => {
   }
 
   const buildData = {
-    buildType,
+    type: buildType,
     branch: buildUrl,
     demoUrl,
     videoUrl,

--- a/packages/backend/routes/builds.js
+++ b/packages/backend/routes/builds.js
@@ -45,12 +45,13 @@ router.get("/builder/:builderAddress", async (req, res) => {
  */
 router.post("/", withRole("builder"), async (req, res) => {
   console.log("POST /builds");
-  const { buildUrl, videoUrl, demoUrl, desc, image, name, signature, coBuilders } = req.body;
+  const { buildType, buildUrl, videoUrl, demoUrl, desc, image, name, signature, coBuilders } = req.body;
   const address = req.address;
 
   const verifyOptions = {
     messageId: "buildSubmit",
     address,
+    buildType,
     buildUrl,
     videoUrl,
     demoUrl,
@@ -67,6 +68,7 @@ router.post("/", withRole("builder"), async (req, res) => {
   }
 
   const buildData = {
+    buildType,
     branch: buildUrl,
     demoUrl,
     videoUrl,

--- a/packages/backend/routes/builds.js
+++ b/packages/backend/routes/builds.js
@@ -146,6 +146,7 @@ router.patch("/:buildId", withRole("builder"), async (req, res) => {
   }
 
   const buildData = {
+    type: buildType,
     branch: buildUrl,
     demoUrl,
     videoUrl,

--- a/packages/backend/routes/builds.js
+++ b/packages/backend/routes/builds.js
@@ -15,16 +15,13 @@ router.get("/", async (req, res) => {
   console.log("/builds");
   // ToDo. Featured not used now, but keeping it for now.
   const featured = req.query.featured ? Boolean(req.query.featured) : null;
+  const buildType = req.query.type;
+  if (buildType) {
+    const builds = await db.findBuildsByType(buildType, featured);
+    res.json(builds);
+    return;
+  }
   const allBuilds = await db.findAllBuilds(featured);
-  res.json(allBuilds);
-});
-
-/**
- * Get all SE-2 Extension Builds.
- */
-router.get("/extensions", async (req, res) => {
-  console.log("/builds/extensions");
-  const allBuilds = await db.findBuildsByType("extension");
   res.json(allBuilds);
 });
 
@@ -110,13 +107,14 @@ router.post("/", withRole("builder"), async (req, res) => {
  */
 router.patch("/:buildId", withRole("builder"), async (req, res) => {
   const buildId = req.params.buildId;
-  const { buildUrl, demoUrl, videoUrl, desc, image, name, signature, coBuilders } = req.body;
+  const { buildType, buildUrl, demoUrl, videoUrl, desc, image, name, signature, coBuilders } = req.body;
   console.log("EDIT /builds/", buildId);
 
   const address = req.address;
 
   const verifyOptions = {
     messageId: "buildEdit",
+    type: buildType,
     address,
     buildId,
     buildUrl,

--- a/packages/backend/routes/builds.js
+++ b/packages/backend/routes/builds.js
@@ -20,6 +20,15 @@ router.get("/", async (req, res) => {
 });
 
 /**
+ * Get all SE-2 Extension Builds.
+ */
+router.get("/extensions", async (req, res) => {
+  console.log("/builds/extensions");
+  const allBuilds = await db.findBuildsByType("extension");
+  res.json(allBuilds);
+});
+
+/**
  * Get a Build by id.
  */
 router.get("/:buildId", async (req, res) => {

--- a/packages/backend/routes/builds.js
+++ b/packages/backend/routes/builds.js
@@ -74,7 +74,7 @@ router.post("/", withRole("builder"), async (req, res) => {
   }
 
   const buildData = {
-    type: buildType,
+    buildType,
     branch: buildUrl,
     demoUrl,
     videoUrl,
@@ -114,7 +114,7 @@ router.patch("/:buildId", withRole("builder"), async (req, res) => {
 
   const verifyOptions = {
     messageId: "buildEdit",
-    type: buildType,
+    buildType,
     address,
     buildId,
     buildUrl,

--- a/packages/backend/services/db/db.js
+++ b/packages/backend/services/db/db.js
@@ -137,6 +137,13 @@ const findBuildById = db.findBuildById;
 const findAllBuilds = db.findAllBuilds;
 
 /**
+ * @param {string} type
+ * @returns {{name: string, builder: string, desc: string, branch: string, readMore: string,
+ *   image: string}[]}
+ */
+const findBuildsByType = db.findBuildsByType;
+
+/**
  * @param {Address} builderAddress
  * @returns {{name: string, desc: string, branch: string, readMore: string,
  *   image: string}[]}
@@ -229,6 +236,7 @@ module.exports = {
   deleteBuild,
   findBuildById,
   findAllBuilds,
+  findBuildsByType,
   findBuilderBuilds,
   featureBuild,
 

--- a/packages/backend/services/db/dbFirebase.js
+++ b/packages/backend/services/db/dbFirebase.js
@@ -249,6 +249,11 @@ const findAllBuilds = async (featured = null) => {
   return buildsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 };
 
+const findBuildsByType = async type => {
+  const buildsSnapshot = await database.collection("builds").where("type", "==", type).get();
+  return buildsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+};
+
 const findBuilderBuilds = async builderAddress => {
   const buildsSnapshot = await database.collection("builds").where("builder", "==", builderAddress).get();
   const coBuildsSnapshot = await database
@@ -436,6 +441,7 @@ module.exports = {
   deleteBuild,
   findBuildById,
   findAllBuilds,
+  findBuildsByType,
   findBuilderBuilds,
   featureBuild,
 

--- a/packages/backend/services/db/dbFirebase.js
+++ b/packages/backend/services/db/dbFirebase.js
@@ -249,8 +249,18 @@ const findAllBuilds = async (featured = null) => {
   return buildsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 };
 
-const findBuildsByType = async type => {
-  const buildsSnapshot = await database.collection("builds").where("type", "==", type).get();
+const findBuildsByType = async (type, featured = null) => {
+  let buildsSnapshot;
+  if (typeof featured === "boolean") {
+    buildsSnapshot = await database
+      .collection("builds")
+      .where("type", "==", type)
+      .where("featured", "==", featured)
+      .get();
+  } else {
+    buildsSnapshot = await database.collection("builds").where("type", "==", type).get();
+  }
+
   return buildsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 };
 

--- a/packages/backend/utils/sign.js
+++ b/packages/backend/utils/sign.js
@@ -6,6 +6,7 @@ const getSignMessageForId = async (messageId, options) => {
   switch (messageId) {
     case "buildSubmit":
       data = {
+        type: options.buildType,
         name: options.name,
         buildUrl: options.buildUrl,
         demoUrl: options.demoUrl,
@@ -23,6 +24,7 @@ const getSignMessageForId = async (messageId, options) => {
 
     case "buildEdit":
       data = {
+        type: options.buildType,
         name: options.name,
         buildUrl: options.buildUrl,
         demoUrl: options.demoUrl,

--- a/packages/react-app/components/BuildCard.jsx
+++ b/packages/react-app/components/BuildCard.jsx
@@ -112,20 +112,22 @@ const BuildCard = ({ build, userProvider, userRole, onUpdate }) => {
         </Link>
       </NextLink>
       <Flex pt={9} pb={4} px={4} direction="column" minH="240px" h="100%" pos="relative" backgroundColor={baseColor}>
-        {build.videoUrl && (
+        {(build.videoUrl || build.type) && (
           <Box pos="absolute" right={0} top={0} pt="6px" pr="12px">
-            <Link href={build.videoUrl} isExternal>
-              <Tooltip label="Watch build video">
-                <YoutubeFilled />
-              </Tooltip>
-            </Link>
+            <BuildTypeBadge type={build.type} />
+            {build.videoUrl && (
+              <Link href={build.videoUrl} isExternal ml={2} display="inline-flex">
+                <Tooltip label="Watch build video">
+                  <YoutubeFilled />
+                </Tooltip>
+              </Link>
+            )}
           </Box>
         )}
         <NextLink href={`/build/${build.id}`} passHref>
           <Link>
             <HStack align="center">
               <Text fontWeight="bold">{build.name}</Text>
-              <BuildTypeBadge type={build.type} />
             </HStack>
           </Link>
         </NextLink>

--- a/packages/react-app/components/BuildCard.jsx
+++ b/packages/react-app/components/BuildCard.jsx
@@ -127,7 +127,7 @@ const BuildCard = ({ build, userProvider, userRole, onUpdate }) => {
               <Text fontWeight="bold">
                 {build.name}
               </Text>
-              <BuildTypeBadge type={build.buildType} />
+              <BuildTypeBadge type={build.type} />
             </HStack>
           </Link>
         </NextLink>

--- a/packages/react-app/components/BuildCard.jsx
+++ b/packages/react-app/components/BuildCard.jsx
@@ -16,7 +16,6 @@ import {
   ButtonGroup,
   Link,
   Tooltip,
-  HStack,
 } from "@chakra-ui/react";
 import { DeleteIcon, EditIcon } from "@chakra-ui/icons";
 import { YoutubeFilled } from "@ant-design/icons";
@@ -126,9 +125,7 @@ const BuildCard = ({ build, userProvider, userRole, onUpdate }) => {
         )}
         <NextLink href={`/build/${build.id}`} passHref>
           <Link>
-            <HStack align="center">
-              <Text fontWeight="bold">{build.name}</Text>
-            </HStack>
+            <Text fontWeight="bold">{build.name}</Text>
           </Link>
         </NextLink>
         <Text color={secondaryFontColor} whiteSpace="pre-wrap" fontSize="sm">

--- a/packages/react-app/components/BuildCard.jsx
+++ b/packages/react-app/components/BuildCard.jsx
@@ -16,6 +16,7 @@ import {
   ButtonGroup,
   Link,
   Tooltip,
+    HStack
 } from "@chakra-ui/react";
 import { DeleteIcon, EditIcon } from "@chakra-ui/icons";
 import { YoutubeFilled } from "@ant-design/icons";
@@ -24,6 +25,7 @@ import { getBuildDeleteSignMessage, deleteBuild } from "../data/api";
 import SubmitBuildModal from "./SubmitBuildModal";
 import { USER_ROLES } from "../helpers/constants";
 import BuildLikeButton from "./BuildLikeButton";
+import BuildTypeBadge from "./BuildTypeBadge";
 
 const BuildCard = ({ build, userProvider, userRole, onUpdate }) => {
   const address = useUserAddress(userProvider);
@@ -121,7 +123,12 @@ const BuildCard = ({ build, userProvider, userRole, onUpdate }) => {
         )}
         <NextLink href={`/build/${build.id}`} passHref>
           <Link>
-            <Text fontWeight="bold">{build.name}</Text>
+            <HStack align="center">
+              <Text fontWeight="bold">
+                {build.name}
+              </Text>
+              <BuildTypeBadge type={build.buildType} />
+            </HStack>
           </Link>
         </NextLink>
         <Text color={secondaryFontColor} whiteSpace="pre-wrap" fontSize="sm">

--- a/packages/react-app/components/BuildCard.jsx
+++ b/packages/react-app/components/BuildCard.jsx
@@ -16,7 +16,7 @@ import {
   ButtonGroup,
   Link,
   Tooltip,
-    HStack
+  HStack,
 } from "@chakra-ui/react";
 import { DeleteIcon, EditIcon } from "@chakra-ui/icons";
 import { YoutubeFilled } from "@ant-design/icons";
@@ -124,9 +124,7 @@ const BuildCard = ({ build, userProvider, userRole, onUpdate }) => {
         <NextLink href={`/build/${build.id}`} passHref>
           <Link>
             <HStack align="center">
-              <Text fontWeight="bold">
-                {build.name}
-              </Text>
+              <Text fontWeight="bold">{build.name}</Text>
               <BuildTypeBadge type={build.type} />
             </HStack>
           </Link>

--- a/packages/react-app/components/BuildDetailHeader.jsx
+++ b/packages/react-app/components/BuildDetailHeader.jsx
@@ -20,6 +20,7 @@ import useCustomColorModes from "../hooks/useCustomColorModes";
 import { ellipsizedAddress } from "../helpers/strings";
 import BlockchainProvidersContext from "../contexts/blockchainProvidersContext";
 import ImageModal from "./ImageModal";
+import BuildTypeBadge from "../components/BuildTypeBadge";
 
 const Builder = ({ builderAddress }) => {
   const mainnetProviderData = useContext(BlockchainProvidersContext).mainnet;
@@ -93,9 +94,13 @@ const BuildDetailHeader = ({ build, actionButtons }) => {
           textAlign={{ base: "center", md: "start" }}
           maxW={{ base: "100%", md: build.image ? "65%" : "none" }}
         >
-          <Heading as="h1" borderColor={textColor} size="lg">
-            {build.name}
-          </Heading>
+          <HStack align="center">
+            <Heading as="h1" borderColor={textColor} size="lg">
+              {build.name}
+            </Heading>
+
+            <BuildTypeBadge fontSize="1em" type={build.type} />
+          </HStack>
           <HStack>{actionButtons}</HStack>
           <Text>{build.desc}</Text>
         </Stack>

--- a/packages/react-app/components/BuildDetailHeader.jsx
+++ b/packages/react-app/components/BuildDetailHeader.jsx
@@ -1,20 +1,7 @@
 import React, { useContext } from "react";
 import NextLink from "next/link";
 import { useLookupAddress } from "eth-hooks";
-import {
-  Heading,
-  Box,
-  Image,
-  HStack,
-  VStack,
-  Flex,
-  Text,
-  Link,
-  Spacer,
-  useDisclosure,
-  Grid,
-  Stack,
-} from "@chakra-ui/react";
+import { Heading, Box, Image, HStack, VStack, Flex, Text, Link, useDisclosure, Stack } from "@chakra-ui/react";
 import QRPunkBlockie from "./QrPunkBlockie";
 import useCustomColorModes from "../hooks/useCustomColorModes";
 import { ellipsizedAddress } from "../helpers/strings";
@@ -94,11 +81,9 @@ const BuildDetailHeader = ({ build, actionButtons }) => {
           textAlign={{ base: "center", md: "start" }}
           maxW={{ base: "100%", md: build.image ? "65%" : "none" }}
         >
-          <HStack align="center">
-            <Heading as="h1" borderColor={textColor} size="lg">
-              {build.name}
-            </Heading>
-          </HStack>
+          <Heading as="h1" borderColor={textColor} size="lg">
+            {build.name}
+          </Heading>
           <HStack>{actionButtons}</HStack>
           <Text>{build.desc}</Text>
           <BuildTypeBadge type={build.type} />

--- a/packages/react-app/components/BuildDetailHeader.jsx
+++ b/packages/react-app/components/BuildDetailHeader.jsx
@@ -98,11 +98,10 @@ const BuildDetailHeader = ({ build, actionButtons }) => {
             <Heading as="h1" borderColor={textColor} size="lg">
               {build.name}
             </Heading>
-
-            <BuildTypeBadge fontSize="1em" type={build.type} />
           </HStack>
           <HStack>{actionButtons}</HStack>
           <Text>{build.desc}</Text>
+          <BuildTypeBadge type={build.type} />
         </Stack>
         {build.image && (
           <Box>

--- a/packages/react-app/components/BuildTypeBadge.jsx
+++ b/packages/react-app/components/BuildTypeBadge.jsx
@@ -1,0 +1,12 @@
+import { Badge } from "@chakra-ui/react";
+
+export default function BuildTypeBadge({ type }) {
+    switch (type) {
+        case "dapp":
+            return <Badge colorScheme="orange">DApp</Badge>;
+        case "extension":
+            return <Badge colorScheme="blue">Extension</Badge>;
+        default:
+            throw new Error(`Unknown build type: ${type}`);
+    }
+}

--- a/packages/react-app/components/BuildTypeBadge.jsx
+++ b/packages/react-app/components/BuildTypeBadge.jsx
@@ -2,20 +2,24 @@ import { Badge } from "@chakra-ui/react";
 import { BUILD_TYPES } from "../helpers/constants";
 
 export default function BuildTypeBadge({ type, ...badgeProps }) {
-    const colorSchemes = {
-        dapp: "orange",
-        extension: "blue",
-        challenge: "green",
-        design: "purple",
-        devrel: "pink",
-        other: "gray"
-    };
+  const colorSchemes = {
+    dapp: "orange",
+    extension: "blue",
+    challenge: "green",
+    design: "purple",
+    devrel: "pink",
+    other: "gray",
+  };
 
-    for (const [key, label] of Object.entries(BUILD_TYPES)) {
-        if (type === key) {
-            return <Badge colorScheme={colorSchemes[key]} {...badgeProps}>{label}</Badge>;
-        }
+  for (const [key, label] of Object.entries(BUILD_TYPES)) {
+    if (type === key) {
+      return (
+        <Badge colorScheme={colorSchemes[key]} {...badgeProps}>
+          {label}
+        </Badge>
+      );
     }
+  }
 
-    throw new Error(`Unknown build type: ${type}`);
+  throw new Error(`Unknown build type: ${type}`);
 }

--- a/packages/react-app/components/BuildTypeBadge.jsx
+++ b/packages/react-app/components/BuildTypeBadge.jsx
@@ -1,27 +1,21 @@
 import { Badge } from "@chakra-ui/react";
 import { BUILD_TYPES } from "../helpers/constants";
 
+const colorSchemes = {
+  dapp: "orange",
+  extension: "blue",
+  challenge: "green",
+  design: "purple",
+  devrel: "pink",
+  other: "gray",
+};
+
 export default function BuildTypeBadge({ type, ...badgeProps }) {
-  if (!type) return null;
+  if (!type || !BUILD_TYPES[type]) return null;
 
-  const colorSchemes = {
-    dapp: "orange",
-    extension: "blue",
-    challenge: "green",
-    design: "purple",
-    devrel: "pink",
-    other: "gray",
-  };
-
-  for (const [key, label] of Object.entries(BUILD_TYPES)) {
-    if (type === key) {
-      return (
-        <Badge colorScheme={colorSchemes[key]} {...badgeProps}>
-          {label}
-        </Badge>
-      );
-    }
-  }
-
-  throw new Error(`Unknown build type: ${type}`);
+  return (
+    <Badge colorScheme={colorSchemes[type]} {...badgeProps}>
+      {BUILD_TYPES[type]}
+    </Badge>
+  );
 }

--- a/packages/react-app/components/BuildTypeBadge.jsx
+++ b/packages/react-app/components/BuildTypeBadge.jsx
@@ -2,6 +2,8 @@ import { Badge } from "@chakra-ui/react";
 import { BUILD_TYPES } from "../helpers/constants";
 
 export default function BuildTypeBadge({ type, ...badgeProps }) {
+  if (!type) return null;
+
   const colorSchemes = {
     dapp: "orange",
     extension: "blue",

--- a/packages/react-app/components/BuildTypeBadge.jsx
+++ b/packages/react-app/components/BuildTypeBadge.jsx
@@ -1,11 +1,11 @@
 import { Badge } from "@chakra-ui/react";
 
-export default function BuildTypeBadge({ type }) {
+export default function BuildTypeBadge({ type, ...badgeProps }) {
     switch (type) {
         case "dapp":
-            return <Badge colorScheme="orange">DApp</Badge>;
+            return <Badge colorScheme="orange" {...badgeProps}>DApp</Badge>;
         case "extension":
-            return <Badge colorScheme="blue">Extension</Badge>;
+            return <Badge colorScheme="blue" {...badgeProps}>Extension</Badge>;
         default:
             throw new Error(`Unknown build type: ${type}`);
     }

--- a/packages/react-app/components/BuildTypeBadge.jsx
+++ b/packages/react-app/components/BuildTypeBadge.jsx
@@ -1,12 +1,21 @@
 import { Badge } from "@chakra-ui/react";
+import { BUILD_TYPES } from "../helpers/constants";
 
 export default function BuildTypeBadge({ type, ...badgeProps }) {
-    switch (type) {
-        case "dapp":
-            return <Badge colorScheme="orange" {...badgeProps}>DApp</Badge>;
-        case "extension":
-            return <Badge colorScheme="blue" {...badgeProps}>Extension</Badge>;
-        default:
-            throw new Error(`Unknown build type: ${type}`);
+    const colorSchemes = {
+        dapp: "orange",
+        extension: "blue",
+        challenge: "green",
+        design: "purple",
+        devrel: "pink",
+        other: "gray"
+    };
+
+    for (const [key, label] of Object.entries(BUILD_TYPES)) {
+        if (type === key) {
+            return <Badge colorScheme={colorSchemes[key]} {...badgeProps}>{label}</Badge>;
+        }
     }
+
+    throw new Error(`Unknown build type: ${type}`);
 }

--- a/packages/react-app/components/SubmitBuildModal.jsx
+++ b/packages/react-app/components/SubmitBuildModal.jsx
@@ -88,7 +88,7 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
 
   useEffect(() => {
     if (isEditingExistingBuild) {
-      setBuildType(build.buildType ?? "dapp");
+      setBuildType(build.type ?? "dapp");
       setBuildName(build.name ?? "");
       setDescription(build.desc ?? "");
       setBuildUrl(build.branch ?? "");

--- a/packages/react-app/components/SubmitBuildModal.jsx
+++ b/packages/react-app/components/SubmitBuildModal.jsx
@@ -21,16 +21,17 @@ import {
   Image,
   Spinner,
   HStack,
-  VStack, RadioGroup, Radio, Select,
+  VStack,
+  Select,
 } from "@chakra-ui/react";
 import { SERVER_URL as serverUrl } from "../constants";
 import useSignedRequest from "../hooks/useSignedRequest";
 import useConnectedAddress from "../hooks/useConnectedAddress";
 import AddressInput from "./AddressInput";
 import BlockchainProvidersContext from "../contexts/blockchainProvidersContext";
-import { AddIcon, DeleteIcon, SmallAddIcon } from "@chakra-ui/icons";
+import { DeleteIcon, SmallAddIcon } from "@chakra-ui/icons";
 import { isAddress } from "ethers/lib/utils";
-import {BUILD_TYPES} from "../helpers/constants"
+import { BUILD_TYPES } from "../helpers/constants";
 
 export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
   const mainnetProviderData = useContext(BlockchainProvidersContext).mainnet;
@@ -118,10 +119,10 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
       imageUrl: false,
       coBuilders: !coBuilders.every(address => isAddress(address)),
       videoUrl:
-          videoUrl.length > 0 &&
-          videoUrl.match(
-              /^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube(-nocookie)?\.com|youtu.be))(\/(?:[\w-]+\?v=|embed\/|v\/)?)([\w-]+)(\S+)?$/g,
-          ) === null,
+        videoUrl.length > 0 &&
+        videoUrl.match(
+          /^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube(-nocookie)?\.com|youtu.be))(\/(?:[\w-]+\?v=|embed\/|v\/)?)([\w-]+)(\S+)?$/g,
+        ) === null,
       buildType: !buildType,
     };
 
@@ -191,9 +192,11 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
             </FormLabel>
             <HStack>
               <Select onChange={e => setBuildType(e.target.value)} value={buildType}>
-                {Object.entries(BUILD_TYPES).map(([key, label]) =>
-                  <option key={key} value={key}>{label}</option>
-                )}
+                {Object.entries(BUILD_TYPES).map(([key, label]) => (
+                  <option key={key} value={key}>
+                    {label}
+                  </option>
+                ))}
               </Select>
             </HStack>
             <FormErrorMessage>This field is required</FormErrorMessage>

--- a/packages/react-app/components/SubmitBuildModal.jsx
+++ b/packages/react-app/components/SubmitBuildModal.jsx
@@ -38,7 +38,7 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
   const isEditingExistingBuild = !!build;
 
   // Submission state.
-  const [buildType, setBuildType] = useState("");
+  const [buildType, setBuildType] = useState("dapp");
   const [buildName, setBuildName] = useState("");
   const [description, setDescription] = useState("");
   const [demoUrl, setDemoUrl] = useState("");
@@ -86,7 +86,7 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
 
   useEffect(() => {
     if (isEditingExistingBuild) {
-      setBuildType(build.buildType ?? "");
+      setBuildType(build.buildType ?? "dapp");
       setBuildName(build.name ?? "");
       setDescription(build.desc ?? "");
       setBuildUrl(build.branch ?? "");
@@ -98,7 +98,7 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
   }, [isEditingExistingBuild, build]);
 
   const clearForm = () => {
-    setBuildType("");
+    setBuildType("dapp");
     setBuildName("");
     setDescription("");
     setBuildUrl("");

--- a/packages/react-app/components/SubmitBuildModal.jsx
+++ b/packages/react-app/components/SubmitBuildModal.jsx
@@ -21,7 +21,7 @@ import {
   Image,
   Spinner,
   HStack,
-  VStack, RadioGroup, Radio,
+  VStack, RadioGroup, Radio, Select,
 } from "@chakra-ui/react";
 import { SERVER_URL as serverUrl } from "../constants";
 import useSignedRequest from "../hooks/useSignedRequest";
@@ -30,6 +30,7 @@ import AddressInput from "./AddressInput";
 import BlockchainProvidersContext from "../contexts/blockchainProvidersContext";
 import { AddIcon, DeleteIcon, SmallAddIcon } from "@chakra-ui/icons";
 import { isAddress } from "ethers/lib/utils";
+import {BUILD_TYPES} from "../helpers/constants"
 
 export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
   const mainnetProviderData = useContext(BlockchainProvidersContext).mainnet;
@@ -189,12 +190,11 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
               <strong>Build Type</strong>
             </FormLabel>
             <HStack>
-              <RadioGroup onChange={setBuildType} value={buildType}>
-                <HStack spacing="24px">
-                  <Radio value="dapp">DApp</Radio>
-                  <Radio value="extension">Extension</Radio>
-                </HStack>
-              </RadioGroup>
+              <Select onChange={e => setBuildType(e.target.value)} value={buildType}>
+                {Object.entries(BUILD_TYPES).map(([key, label]) =>
+                  <option key={key} value={key}>{label}</option>
+                )}
+              </Select>
             </HStack>
             <FormErrorMessage>This field is required</FormErrorMessage>
           </FormControl>

--- a/packages/react-app/components/SubmitBuildModal.jsx
+++ b/packages/react-app/components/SubmitBuildModal.jsx
@@ -21,7 +21,7 @@ import {
   Image,
   Spinner,
   HStack,
-  VStack,
+  VStack, RadioGroup, Radio,
 } from "@chakra-ui/react";
 import { SERVER_URL as serverUrl } from "../constants";
 import useSignedRequest from "../hooks/useSignedRequest";
@@ -38,6 +38,7 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
   const isEditingExistingBuild = !!build;
 
   // Submission state.
+  const [buildType, setBuildType] = useState("");
   const [buildName, setBuildName] = useState("");
   const [description, setDescription] = useState("");
   const [demoUrl, setDemoUrl] = useState("");
@@ -85,6 +86,7 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
 
   useEffect(() => {
     if (isEditingExistingBuild) {
+      setBuildType(build.buildType ?? "");
       setBuildName(build.name ?? "");
       setDescription(build.desc ?? "");
       setBuildUrl(build.branch ?? "");
@@ -96,6 +98,7 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
   }, [isEditingExistingBuild, build]);
 
   const clearForm = () => {
+    setBuildType("");
     setBuildName("");
     setDescription("");
     setBuildUrl("");
@@ -114,10 +117,11 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
       imageUrl: false,
       coBuilders: !coBuilders.every(address => isAddress(address)),
       videoUrl:
-        videoUrl.length > 0 &&
-        videoUrl.match(
-          /^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube(-nocookie)?\.com|youtu.be))(\/(?:[\w-]+\?v=|embed\/|v\/)?)([\w-]+)(\S+)?$/g,
-        ) === null,
+          videoUrl.length > 0 &&
+          videoUrl.match(
+              /^((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube(-nocookie)?\.com|youtu.be))(\/(?:[\w-]+\?v=|embed\/|v\/)?)([\w-]+)(\S+)?$/g,
+          ) === null,
+      buildType: !buildType,
     };
 
     setErrors(nextErrors);
@@ -136,6 +140,7 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
           image: imageUrl,
           name: buildName,
           coBuilders,
+          buildType,
         });
       } else {
         await makeSignedRequest({
@@ -146,6 +151,7 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
           image: imageUrl,
           name: buildName,
           coBuilders,
+          buildType,
         });
       }
     } catch (error) {
@@ -178,6 +184,20 @@ export default function SubmitBuildModal({ isOpen, onClose, build, onUpdate }) {
         <ModalHeader>{isEditingExistingBuild ? "Edit" : "New"} Build</ModalHeader>
         <ModalCloseButton />
         <ModalBody px={8} pb={8}>
+          <FormControl mb={4} isRequired isInvalid={errors.buildType}>
+            <FormLabel htmlFor="buildType">
+              <strong>Build Type</strong>
+            </FormLabel>
+            <HStack>
+              <RadioGroup onChange={setBuildType} value={buildType}>
+                <HStack spacing="24px">
+                  <Radio value="dapp">DApp</Radio>
+                  <Radio value="extension">Extension</Radio>
+                </HStack>
+              </RadioGroup>
+            </HStack>
+            <FormErrorMessage>This field is required</FormErrorMessage>
+          </FormControl>
           <FormControl mb={4} isRequired isInvalid={errors.buildName}>
             <FormLabel htmlFor="buildName">
               <strong>Build name</strong>

--- a/packages/react-app/components/home/RecentBuildsSection.jsx
+++ b/packages/react-app/components/home/RecentBuildsSection.jsx
@@ -5,6 +5,7 @@ import Card from "../Card";
 import { Flex, Button, VStack, Container, Divider, Heading, chakra, Text, Link } from "@chakra-ui/react";
 import useCustomColorModes from "../../hooks/useCustomColorModes";
 import DateWithTooltip from "../DateWithTooltip";
+import BuildTypeBadge from "../BuildTypeBadge";
 
 const MAX_DESC_LEN = 150;
 const RecentBuildCard = ({ build }) => {
@@ -17,6 +18,7 @@ const RecentBuildCard = ({ build }) => {
           <Heading size="md" fontWeight="500">
             {build.name}
           </Heading>
+          <BuildTypeBadge type={build.type} />
         </VStack>
         <Divider />
         <VStack align="start" spacing={3} p={5} bg={baseBlue2Color}>

--- a/packages/react-app/data/api/builds.js
+++ b/packages/react-app/data/api/builds.js
@@ -5,7 +5,7 @@ import { getGithubApiReadmeFromRepoUrl, getGithubReadmeUrlFromBranchUrl, isGithu
 export const postBuildSubmit = async (
   address,
   signature,
-  { buildUrl, videoUrl, demoUrl, desc, image, name, coBuilders },
+  { buildUrl, videoUrl, demoUrl, desc, image, name, coBuilders, buildType },
 ) => {
   try {
     await axios.post(
@@ -19,6 +19,7 @@ export const postBuildSubmit = async (
         name,
         coBuilders,
         signature,
+        buildType,
       },
       {
         headers: {
@@ -40,7 +41,7 @@ export const postBuildSubmit = async (
 export const patchBuildEdit = async (
   address,
   signature,
-  { buildId, buildUrl, videoUrl, demoUrl, desc, image, name, coBuilders },
+  { buildId, buildUrl, videoUrl, demoUrl, desc, image, name, coBuilders, buildType },
 ) => {
   try {
     await axios.patch(
@@ -54,6 +55,7 @@ export const patchBuildEdit = async (
         name,
         coBuilders,
         signature,
+        buildType,
       },
       {
         headers: {

--- a/packages/react-app/helpers/constants.js
+++ b/packages/react-app/helpers/constants.js
@@ -4,6 +4,15 @@ export const SRE_CHALLENGE_SUBMISSION_STATUS = {
   SUBMITTED: "SUBMITTED",
 };
 
+export const BUILD_TYPES = {
+  dapp: "DApp",
+  extension: "Extension",
+  challenge: "Challenge",
+  design: "Design",
+  devrel: "DevRel",
+  other: "Other",
+};
+
 export const USER_ROLES = {
   anonymous: "anonymous",
   builder: "builder",

--- a/packages/react-app/helpers/constants.js
+++ b/packages/react-app/helpers/constants.js
@@ -5,9 +5,9 @@ export const SRE_CHALLENGE_SUBMISSION_STATUS = {
 };
 
 export const BUILD_TYPES = {
-  dapp: "DApp",
-  extension: "Extension",
-  challenge: "Challenge",
+  dapp: "SE-2 DApp",
+  extension: "SE-2 Extension",
+  challenge: "SRE Challenge",
   design: "Design",
   devrel: "DevRel",
   other: "Other",


### PR DESCRIPTION
After the release of SE-2 Extensions, I thought it would be neat to add a method for users to share their community-built extensions. This PR adds a `type` parameter to each build, marking the type. Currently, a `dapp` is the original "build", and an `extension` is, well, an extension.

Specifically, this PR adds:
- A choice in the create/edit modal allowing the user to specify the type of build this is
- A field in each build, `type`, storing the type of the build
- An endpoint, `/builds/extensions`, listing out builds that have a `type` of `"extension"`

Notes:
- The code expects every build to have a `type` field. To keep the code clean, I have opted to not add code filling in a default value. Therefore, it requires adding `type: dapp` to all existing builds.

After we iron out this PR, I will make another one in the [scaffoldeth.io repo](https://github.com/scaffold-eth/scaffoldeth.io) that adds a page listing out these extensions.