### PR TITLE
make batch data dynamic on the banner

### DIFF
--- a/packages/backend/routes/batches.js
+++ b/packages/backend/routes/batches.js
@@ -12,6 +12,12 @@ router.get("/", async (req, res) => {
   res.status(200).send(batches);
 });
 
+router.get("/latest-open", async (req, res) => {
+  console.log("/batches/latest-open");
+  const batch = await db.findLatestOpenBatch();
+  res.status(200).send(batch);
+});
+
 router.post("/create", withRole("admin"), async (req, res) => {
   const neededBodyProps = ["batchName", "batchStatus", "batchStartDate", "batchTelegramLink"];
   if (neededBodyProps.some(prop => req.body[prop] === undefined)) {

--- a/packages/backend/services/db/db.js
+++ b/packages/backend/services/db/db.js
@@ -63,6 +63,7 @@ const findBatchByName = db.findBatchByName;
 const findBatchById = db.findBatchById;
 const createBatch = db.createBatch;
 const updateBatch = db.updateBatch;
+const findLatestOpenBatch = db.findLatestOpenBatch;
 
 // --- Cohorts
 /**
@@ -244,6 +245,7 @@ module.exports = {
   findBatchById,
   createBatch,
   updateBatch,
+  findLatestOpenBatch,
 
   createEvent,
   findAllEvents,

--- a/packages/backend/services/db/dbFirebase.js
+++ b/packages/backend/services/db/dbFirebase.js
@@ -90,6 +90,20 @@ const findAllBatches = async () => {
   return batchesSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 };
 
+const findLatestOpenBatch = async () => {
+  const batchesSnapshot = await database
+    .collection("batches")
+    .where("status", "==", "open")
+    .orderBy("startDate", "desc")
+    .limit(1)
+    .get();
+  if (batchesSnapshot.empty) {
+    return { exists: false };
+  }
+  const batchDoc = batchesSnapshot.docs[0];
+  return { exists: true, data: { id: batchDoc.id, ...batchDoc.data() } };
+};
+
 const findBatchByName = async batchName => {
   const batchesSnapshot = await database.collection("batches").where("name", "==", batchName).get();
   if (batchesSnapshot.empty) {
@@ -500,6 +514,7 @@ module.exports = {
   findBatchById,
   createBatch,
   updateBatch,
+  findLatestOpenBatch,
 
   createEvent,
   findAllEvents,

--- a/packages/react-app/.sample.env
+++ b/packages/react-app/.sample.env
@@ -3,9 +3,3 @@ NEXT_PUBLIC_ENVIRONMENT=development
 NEXT_PUBLIC_BACKEND_URL=http://localhost:49833
 NEXT_PUBLIC_SRE_BACKEND_URL=https://scaffold-directory-dev.ew.r.appspot.com
 NEXT_PUBLIC_FUNDER_CONTRACT_ADDRESS=0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
-# Telegram join link shown in notification
-NEXT_PUBLIC_BATCH_TELEGRAM=
-# Date of next starting date shown in notification
-NEXT_PUBLIC_BATCH_DATE=
-# The batch number the builder wants to join is saved in the database
-NEXT_PUBLIC_BATCH_NUMBER=

--- a/packages/react-app/components/notifications/OnboardingBatch.jsx
+++ b/packages/react-app/components/notifications/OnboardingBatch.jsx
@@ -18,7 +18,7 @@ import { useState, useCallback, useEffect } from "react";
 import axios from "axios";
 import moment from "moment";
 
-const serverPathBatches = "/batches/latest-open";
+const serverPath = "/batches/latest-open";
 
 const OnboardingBatch = ({ notification, onMarkAsRead, builder, userProvider, onUpdate }) => {
   const address = useUserAddress(userProvider);
@@ -34,7 +34,7 @@ const OnboardingBatch = ({ notification, onMarkAsRead, builder, userProvider, on
   const fetchLatestOpenBatch = useCallback(async () => {
     setIsLoadingOpenBatch(true);
     try {
-      const fetchedBatch = await axios.get(SERVER_URL + serverPathBatches);
+      const fetchedBatch = await axios.get(SERVER_URL + serverPath);
       setLatestOpenBatch(fetchedBatch.data.data);
     } catch (error) {
       console.error("Error fetching batch:", error);

--- a/packages/react-app/components/notifications/OnboardingBatch.jsx
+++ b/packages/react-app/components/notifications/OnboardingBatch.jsx
@@ -13,23 +13,43 @@ import {
 } from "@chakra-ui/react";
 import { getUpdateBatchSignMessage, postUpdateBatch } from "../../data/api";
 import { useUserAddress } from "eth-hooks";
+import { SERVER_URL } from "../../constants";
+import { useState, useCallback, useEffect } from "react";
+import axios from "axios";
+import moment from "moment";
 
-const NEXT_BATCH_TELEGRAM = process.env.NEXT_PUBLIC_BATCH_TELEGRAM;
-const NEXT_BATCH_DATE = process.env.NEXT_PUBLIC_BATCH_DATE;
-const NEXT_BATCH = process.env.NEXT_PUBLIC_BATCH_NUMBER;
+const serverPathBatches = "/batches/latest-open";
 
 const OnboardingBatch = ({ notification, onMarkAsRead, builder, userProvider, onUpdate }) => {
   const address = useUserAddress(userProvider);
+  const [latestOpenBatch, setLatestOpenBatch] = useState(null);
+  const [isLoadingOpenBatch, setIsLoadingOpenBatch] = useState(false);
 
   const hasBatchNumber = builder?.batch?.number;
-  const isInRecentBatch = builder?.batch?.number === NEXT_BATCH;
+  const isInRecentBatch = builder?.batch?.number === latestOpenBatch?.name;
 
   const toast = useToast({ position: "top", isClosable: true });
   const toastVariant = useColorModeValue("subtle", "solid");
 
+  const fetchLatestOpenBatch = useCallback(async () => {
+    setIsLoadingOpenBatch(true);
+    try {
+      const fetchedBatch = await axios.get(SERVER_URL + serverPathBatches);
+      setLatestOpenBatch(fetchedBatch.data.data);
+    } catch (error) {
+      console.error("Error fetching batch:", error);
+    } finally {
+      setIsLoadingOpenBatch(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLatestOpenBatch();
+  }, [fetchLatestOpenBatch]);
+
   const handleUpdateBatch = async () => {
     const batchData = {
-      number: NEXT_BATCH,
+      number: latestOpenBatch?.name,
       status: "candidate",
     };
 
@@ -80,55 +100,62 @@ const OnboardingBatch = ({ notification, onMarkAsRead, builder, userProvider, on
   };
 
   const handleJoinTelegram = () => {
-    window.open(NEXT_BATCH_TELEGRAM);
+    window.open(latestOpenBatch?.telegramLink);
   };
 
   return (
-    <Flex background="linear-gradient(180deg, #EAFFA9 24.48%, #EDEFFF 100%)" position="relative">
-      <Flex width={{ base: "100%", md: "60%" }} px="30px" py="30px" direction="column">
-        <Box maxW="200px">
-          <Image src="/assets/onboarding_batches_logo.png" alt="onboarding batches illustration: futuristic train" />
-        </Box>
-        <Text fontSize="30px" fontWeight="bold" lineHeight="1.2" color="gray.800">
-          Welcome to BuidlGuidl!
-        </Text>
-        <Text fontSize="sm" my="2" color="gray.800">
-          To help you get started in the Ethereum ecosystem, we've created the BuidlGuidl onboarding batch program. Dive
-          into end-to-end dApp development, receive mentorship from BG members, and learn how to collaborate with fellow
-          developers in open-source projects.
-        </Text>
-        <Spacer />
-        <Flex alignItems="center" flexDirection="row">
-          <Box mr="5">
-            {hasBatchNumber ? (
-              <Button
-                colorScheme="blue"
-                size="sm"
-                onClick={handleJoinTelegram}
-                isDisabled={!isInRecentBatch}
-                width="180px"
-              >
-                Join Telegram
-              </Button>
-            ) : (
-              <Button colorScheme="orange" size="sm" onClick={handleUpdateBatch} width="180px">
-                Get Telegram Access
-              </Button>
-            )}
+    <>
+      {!isLoadingOpenBatch && latestOpenBatch && (!hasBatchNumber || isInRecentBatch) && (
+        <Flex background="linear-gradient(180deg, #EAFFA9 24.48%, #EDEFFF 100%)" position="relative">
+          <Flex width={{ base: "100%", md: "60%" }} px="30px" py="30px" direction="column">
+            <Box maxW="200px">
+              <Image
+                src="/assets/onboarding_batches_logo.png"
+                alt="onboarding batches illustration: futuristic train"
+              />
+            </Box>
+            <Text fontSize="30px" fontWeight="bold" lineHeight="1.2" color="gray.800">
+              Welcome to BuidlGuidl!
+            </Text>
+            <Text fontSize="sm" my="2" color="gray.800">
+              To help you get started in the Ethereum ecosystem, we've created the BuidlGuidl onboarding batch program.
+              Dive into end-to-end dApp development, receive mentorship from BG members, and learn how to collaborate
+              with fellow developers in open-source projects.
+            </Text>
+            <Spacer />
+            <Flex alignItems="center" flexDirection="row">
+              <Box mr="5">
+                {hasBatchNumber ? (
+                  <Button
+                    colorScheme="blue"
+                    size="sm"
+                    onClick={handleJoinTelegram}
+                    isDisabled={!isInRecentBatch}
+                    width="180px"
+                  >
+                    Join Telegram
+                  </Button>
+                ) : (
+                  <Button colorScheme="orange" size="sm" onClick={handleUpdateBatch} width="180px">
+                    Get Telegram Access
+                  </Button>
+                )}
+              </Box>
+              <Text fontSize="xs" color="gray.800">
+                Next batch <strong>{latestOpenBatch?.name}</strong> starting on <br />
+                <strong>{moment(latestOpenBatch?.startDate).format("MMMM D, YYYY")}</strong>
+              </Text>
+            </Flex>
+          </Flex>
+          <Box width="50%" display={{ base: "none", md: "inline-block" }}>
+            <Image src="/assets/onboarding_batches.png" alt="onboarding batches illustration: futuristic train" />
           </Box>
-          <Text fontSize="xs" color="gray.800">
-            Next batch starting on <br />
-            <strong>{NEXT_BATCH_DATE}</strong>
-          </Text>
+          <Tooltip label="Mark as Read" aria-label="Mark as Read">
+            <CloseButton position="absolute" right="4px" top="4px" onClick={() => onMarkAsRead(notification.id)} />
+          </Tooltip>
         </Flex>
-      </Flex>
-      <Box width="50%" display={{ base: "none", md: "inline-block" }}>
-        <Image src="/assets/onboarding_batches.png" alt="onboarding batches illustration: futuristic train" />
-      </Box>
-      <Tooltip label="Mark as Read" aria-label="Mark as Read">
-        <CloseButton position="absolute" right="4px" top="4px" onClick={() => onMarkAsRead(notification.id)} />
-      </Tooltip>
-    </Flex>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION

Hey,

I’ve updated the batch banner to pull data directly from the database, so we can remove the environment variables `NEXT_PUBLIC_BATCH_TELEGRAM`, `NEXT_PUBLIC_BATCH_DATE`, and `NEXT_PUBLIC_BATCH_NUMBER`.

From a front-end perspective, I made minimal changes—just added the batch number/name to the “Next batch X starting on” note (see screenshot).

<img width="900" alt="Screenshot 2024-10-29 at 17 23 28" src="https://github.com/user-attachments/assets/20f3c94d-30eb-4b1a-a435-f55109a3dae8">

The banner is displayed to builders who haven't joined a batch yet or are in the latest open batch.