### PR TITLE
Add ntf contract address to batch data

### DIFF
--- a/packages/backend/routes/batches.js
+++ b/packages/backend/routes/batches.js
@@ -142,8 +142,8 @@ router.patch("/update", withRole("admin"), async (req, res) => {
     batchData.contractAddress = batchContractAddress;
     batchData.nftContractAddress = await getNFTContractAddress(batchContractAddress);
   } else {
-    batchData.contractAddress = "0x0000000000000000000000000000000000000000";
-    batchData.nftContractAddress = "0x0000000000000000000000000000000000000000";
+    batchData.contractAddress = "";
+    batchData.nftContractAddress = "";
   }
 
   //   Update batch

--- a/packages/backend/routes/batches.js
+++ b/packages/backend/routes/batches.js
@@ -24,6 +24,7 @@ router.get("/", async (req, res) => {
       startDate: batch.startDate,
       telegramLink: batch.telegramLink,
       contractAddress: batch.contractAddress,
+      nftContractAddress: batch.nftContractAddress,
       totalParticipants: batchBuilders.length,
       graduates: batchGraduates.length,
     };

--- a/packages/backend/routes/batches.js
+++ b/packages/backend/routes/batches.js
@@ -138,12 +138,12 @@ router.patch("/update", withRole("admin"), async (req, res) => {
     telegramLink: batchTelegramLink,
   };
 
-  if (batchContractAddress) {
-    batchData.contractAddress = batchContractAddress;
-    batchData.nftContractAddress = await getNFTContractAddress(batchContractAddress);
-  } else {
+  if (!batchContractAddress) {
     batchData.contractAddress = "";
     batchData.nftContractAddress = "";
+  } else if (batchContractAddress !== batch.data.contractAddress) {
+    batchData.contractAddress = batchContractAddress;
+    batchData.nftContractAddress = await getNFTContractAddress(batchContractAddress);
   }
 
   //   Update batch

--- a/packages/backend/routes/batches.js
+++ b/packages/backend/routes/batches.js
@@ -3,6 +3,7 @@ const { ethers } = require("ethers");
 const db = require("../services/db/db");
 const { verifySignature } = require("../utils/sign");
 const { withRole } = require("../middlewares/auth");
+const { getNFTContractAddress } = require("../utils/contracts");
 
 const router = express.Router();
 
@@ -85,6 +86,7 @@ router.post("/create", withRole("admin"), async (req, res) => {
 
   if (batchContractAddress) {
     batchData.contractAddress = batchContractAddress;
+    batchData.nftContractAddress = await getNFTContractAddress(batchContractAddress);
   }
 
   // Create batch.
@@ -138,6 +140,10 @@ router.patch("/update", withRole("admin"), async (req, res) => {
 
   if (batchContractAddress) {
     batchData.contractAddress = batchContractAddress;
+    batchData.nftContractAddress = await getNFTContractAddress(batchContractAddress);
+  } else {
+    batchData.contractAddress = "0x0000000000000000000000000000000000000000";
+    batchData.nftContractAddress = "0x0000000000000000000000000000000000000000";
   }
 
   //   Update batch

--- a/packages/backend/scripts/20241207_add_nft_contract_address_to_batch.js
+++ b/packages/backend/scripts/20241207_add_nft_contract_address_to_batch.js
@@ -8,15 +8,12 @@
 require("dotenv").config();
 const firebaseAdmin = require("firebase-admin");
 const { getNFTContractAddress } = require("../utils/contracts");
-// const { importSeed } = require("../local_database/importSeed");
 
 if (process.env.FIRESTORE_EMULATOR_HOST) {
   firebaseAdmin.initializeApp({
     projectId: "buidlguidl-v3",
     storageBucket: "buidlguidl-v3.appspot.com",
   });
-
-  // importSeed(firebaseAdmin.firestore());
 } else if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
   console.log("using Firebase live DB");
   firebaseAdmin.initializeApp({
@@ -29,7 +26,6 @@ if (process.env.FIRESTORE_EMULATOR_HOST) {
   });
 }
 
-// // Docs: https://firebase.google.com/docs/firestore/quickstart#node.js_1
 const db = firebaseAdmin.firestore();
 
 const main = async () => {

--- a/packages/backend/scripts/20241207_add_nft_contract_address_to_batch.js
+++ b/packages/backend/scripts/20241207_add_nft_contract_address_to_batch.js
@@ -1,0 +1,58 @@
+/** Add NFT contract address to each batch
+ *  {
+    ...batch,
+    contractAddress: "0x0A7d97d392e7400D15460ae0C9799951a3719393",
+  }
+ * */
+
+require("dotenv").config();
+const firebaseAdmin = require("firebase-admin");
+const { getNFTContractAddress } = require("../utils/contracts");
+// const { importSeed } = require("../local_database/importSeed");
+
+if (process.env.FIRESTORE_EMULATOR_HOST) {
+  firebaseAdmin.initializeApp({
+    projectId: "buidlguidl-v3",
+    storageBucket: "buidlguidl-v3.appspot.com",
+  });
+
+  // importSeed(firebaseAdmin.firestore());
+} else if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+  console.log("using Firebase live DB");
+  firebaseAdmin.initializeApp({
+    credential: firebaseAdmin.credential.applicationDefault(),
+    storageBucket: "buidlguidl-v3.appspot.com",
+  });
+} else {
+  firebaseAdmin.initializeApp({
+    storageBucket: "buidlguidl-v3.appspot.com",
+  });
+}
+
+// // Docs: https://firebase.google.com/docs/firestore/quickstart#node.js_1
+const db = firebaseAdmin.firestore();
+
+const main = async () => {
+  try {
+    console.log("add nft contract address to each batch...");
+
+    const batchesSnapshot = await db.collection("batches").get();
+    const batchPromises = batchesSnapshot.docs.map(async doc => {
+      const batch = doc.data();
+      if (batch.contractAddress) {
+        const nftContractAddress = await getNFTContractAddress(batch.contractAddress);
+        await db.collection("batches").doc(doc.id).update({
+          nftContractAddress,
+        });
+        console.log(`Updated batch ${batch.name} with NFT contract address: ${nftContractAddress}`);
+      }
+    });
+
+    await Promise.all(batchPromises);
+    console.log("All batches updated successfully!");
+  } catch (error) {
+    console.error("Error updating batches:", error);
+  }
+};
+
+main();

--- a/packages/backend/scripts/20241207_add_nft_contract_address_to_batch.js
+++ b/packages/backend/scripts/20241207_add_nft_contract_address_to_batch.js
@@ -37,9 +37,15 @@ const main = async () => {
       const batch = doc.data();
       if (batch.contractAddress) {
         const nftContractAddress = await getNFTContractAddress(batch.contractAddress);
+        if (!nftContractAddress) {
+          console.log("Skipping batch", batch.name);
+          return;
+        }
+
         await db.collection("batches").doc(doc.id).update({
           nftContractAddress,
         });
+
         console.log(`Updated batch ${batch.name} with NFT contract address: ${nftContractAddress}`);
       }
     });

--- a/packages/backend/utils/contracts.js
+++ b/packages/backend/utils/contracts.js
@@ -13,7 +13,7 @@ async function getNFTContractAddress(contractAddress) {
     return nftContractAddress;
   } catch (error) {
     console.log("Could not fetch NFT contract address:", error.message);
-    return "0x0000000000000000000000000000000000000000";
+    return "";
   }
 }
 

--- a/packages/backend/utils/contracts.js
+++ b/packages/backend/utils/contracts.js
@@ -1,0 +1,22 @@
+const { ethers } = require("ethers");
+
+async function getNFTContractAddress(contractAddress) {
+  try {
+    const provider = new ethers.providers.JsonRpcProvider(process.env.OP_RPC_URL);
+    const contract = new ethers.Contract(
+      contractAddress,
+      ["function batchGraduationNFT() view returns (address)"],
+      provider,
+    );
+
+    const nftContractAddress = await contract.batchGraduationNFT();
+    return nftContractAddress;
+  } catch (error) {
+    console.log("Could not fetch NFT contract address:", error.message);
+    return "0x0000000000000000000000000000000000000000";
+  }
+}
+
+module.exports = {
+  getNFTContractAddress,
+};

--- a/packages/backend/utils/contracts.js
+++ b/packages/backend/utils/contracts.js
@@ -12,7 +12,7 @@ async function getNFTContractAddress(contractAddress) {
     const nftContractAddress = await contract.batchGraduationNFT();
     return nftContractAddress;
   } catch (error) {
-    console.log("Could not fetch NFT contract address:", error.message);
+    console.error("Could not fetch NFT contract address:", error.message);
     return "";
   }
 }


### PR DESCRIPTION
Hi Carlos,

This PR adds the NFT contract address to the batch data point.

I went for your suggested automatic approach, fetching the address using ethers on the backend. 
However, I was unsure whether to set the attribute to the zero address or an empty string when the address is unavailable. I decided to go with an empty string.

(There is no migration. We can just edit the batches and submit it to the database, then the data should be fetched.)

Let me know what you think.

Best,
Philip