### PR TITLE
Use Ponder to get info on /admin/cohorts page

### DIFF
--- a/packages/react-app/constants.js
+++ b/packages/react-app/constants.js
@@ -297,6 +297,7 @@ export const NETWORK = chainId => {
 
 // export const SERVER_URL = "https://backend.ether.delivery:49832"
 export const SERVER_URL = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:49832";
+export const PONDER_URL = process.env.NEXT_PUBLIC_PONDER_URL ?? "http://localhost:42069";
 export const SRE_SERVER_URL = process.env.NEXT_PUBLIC_SRE_BACKEND_URL ?? "http://localhost:49832";
 export const ENVIRONMENT = process.env.NEXT_PUBLIC_ENVIRONMENT ?? "development";
 


### PR DESCRIPTION
This PR has to be merged after https://github.com/BuidlGuidl/bg-ponder-indexer/pull/9 is merged.

The https://app.buidlguidl.com/admin/cohorts page is getting the data from the BG Ponder indexer now.

![localhost_3001_admin_cohorts (1)](https://github.com/user-attachments/assets/54c8f051-194e-41a6-a740-9552d1100d73)

The data is almost the same as the current data shown; the address from the builder was added to the last withdraw data.

Added NEXT_PUBLIC_PONDER_URL env variable. This needs to be set when deploying to production.