### PR TITLE
Fetch SREv2 builder data from SRE v2

### DIFF
--- a/packages/react-app/components/BuilderChallengesTable.jsx
+++ b/packages/react-app/components/BuilderChallengesTable.jsx
@@ -7,7 +7,7 @@ import useCustomColorModes from "../hooks/useCustomColorModes";
 
 const SRE_FRONTEND = "https://speedrunethereum.com";
 
-export default function BuilderChallengesTable({ challenges, isLoadingTimestamps, challengeEvents }) {
+export default function BuilderChallengesTable({ challenges, isLoadingTimestamps }) {
   const { baseColor } = useCustomColorModes();
 
   return (
@@ -27,13 +27,11 @@ export default function BuilderChallengesTable({ challenges, isLoadingTimestamps
             </Tr>
           </Thead>
           <Tbody>
-            {challenges.map(([challengeId, lastSubmission]) => {
+            {challenges.map(challenge => {
+              const challengeId = challenge.challengeId;
               if (!SreChallengeInfo[challengeId]) {
                 return null;
               }
-              const lastEventForChallenge = challengeEvents?.filter(
-                event => event.payload.challengeId === challengeId,
-              )[0];
 
               return (
                 <Tr key={challengeId}>
@@ -48,18 +46,12 @@ export default function BuilderChallengesTable({ challenges, isLoadingTimestamps
                     </Link>
                   </Td>
                   <Td>
-                    <Link
-                      // Legacy branchUrl
-                      href={lastSubmission.contractUrl || lastSubmission.branchUrl}
-                      color="teal.500"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
+                    <Link href={challenge.contractUrl} color="teal.500" target="_blank" rel="noopener noreferrer">
                       Code
                     </Link>
                   </Td>
                   <Td>
-                    <Link href={lastSubmission.deployedUrl} color="teal.500" target="_blank" rel="noopener noreferrer">
+                    <Link href={challenge.frontendUrl} color="teal.500" target="_blank" rel="noopener noreferrer">
                       Demo
                     </Link>
                   </Td>
@@ -67,14 +59,14 @@ export default function BuilderChallengesTable({ challenges, isLoadingTimestamps
                     {isLoadingTimestamps ? (
                       <SkeletonText noOfLines={1} />
                     ) : (
-                      <DateWithTooltip timestamp={lastEventForChallenge?.timestamp} />
+                      <DateWithTooltip timestamp={challenge.submittedAt} />
                     )}
                   </Td>
                   <Td>
                     <ChallengeStatusTag
-                      status={lastSubmission.status}
-                      comment={lastSubmission.reviewComment}
-                      autograding={lastSubmission.autograding}
+                      status={challenge.reviewAction}
+                      comment={challenge.reviewComment}
+                      autograding={challenge.challenge.autograding}
                     />
                   </Td>
                 </Tr>

--- a/packages/react-app/data/api/sre.js
+++ b/packages/react-app/data/api/sre.js
@@ -1,22 +1,12 @@
 import axios from "axios";
 import { SRE_SERVER_URL as SreServerUrl } from "../../constants";
 
-export const getSreBuilder = async address => {
+export const getSreBuilderChallengeData = async address => {
   try {
-    const response = await axios.get(`${SreServerUrl}/builders/${address}`);
+    const response = await axios.get(`${SreServerUrl}/api/user-challenges/${address}`);
     return response.data;
   } catch (error) {
     console.error(error);
-    return {};
-  }
-};
-
-export const getChallengeEventsForUser = async userId => {
-  try {
-    const response = await axios.get(`${SreServerUrl}/events?user=${userId}&type=challenge.submit,challenge.review`);
-    return response.data;
-  } catch (err) {
-    console.log(`error fetching events for user ${userId}.`, err);
-    return [];
+    return { challenges: [] };
   }
 };


### PR DESCRIPTION
This fetches the Builder Challenge data from the new API on SREv2

To be merged when SREv2 is live.

To test (no need to set up the database locally).

`packages/react-app/.env`

```
NEXT_PUBLIC_BACKEND_URL=https://buidlguidl-v3.ew.r.appspot.com
NEXT_PUBLIC_SRE_BACKEND_URL=https://speedrunethereum-v2.vercel.app
```

This will launch the front end pointing to the live BG3.5 data + staging SREv2, so you can test with any real user.

I was getting CORS errors, so I used https://chromewebstore.google.com/detail/cors-unblock/lfhmikememgdcahcdlaciloancbhjino

P.S I didnt handle edge cases like "state channels". I don't think it's worth it (BG/SRE link to be removed...)
