### PR TITLE
Disable write functionality

### DIFF
--- a/packages/backend/middlewares/auth.js
+++ b/packages/backend/middlewares/auth.js
@@ -58,8 +58,19 @@ const withApiKey = (req, res, next) => {
   next();
 };
 
+/**
+ * Middleware to disable write operations and return read-only mode message
+ */
+const readOnlyMode = (req, res, next) => {
+  res.status(503).json({
+    error: "BG3.5 backend is in read-only mode",
+    message: "Due to SRE migration, the backend is in read-only mode for most of its operations.",
+  });
+};
+
 module.exports = {
   withAddress,
   withRole,
   withApiKey,
+  readOnlyMode,
 };

--- a/packages/backend/routes/api.js
+++ b/packages/backend/routes/api.js
@@ -2,14 +2,14 @@ const express = require("express");
 const { ethers } = require("ethers");
 const db = require("../services/db/db");
 const { createEvent, EVENT_TYPES } = require("../utils/events");
-const { withApiKey } = require("../middlewares/auth");
+const { withApiKey, readOnlyMode } = require("../middlewares/auth");
 const { getEnsFromAddress } = require("../utils/ens");
 const moment = require("moment");
 
 const router = express.Router();
 
 // ToDo. Api Auth Middleware
-router.post("/builders/create", withApiKey, async (req, res) => {
+router.post("/builders/create", readOnlyMode, withApiKey, async (req, res) => {
   const { builderAddress, existingBuilderData } = req.body;
   if (builderAddress === undefined) {
     res.status(400).send(`Missing required "builderAddress" body property`);

--- a/packages/backend/routes/batches.js
+++ b/packages/backend/routes/batches.js
@@ -2,7 +2,7 @@ const express = require("express");
 const { ethers } = require("ethers");
 const db = require("../services/db/db");
 const { verifySignature } = require("../utils/sign");
-const { withRole } = require("../middlewares/auth");
+const { withRole, readOnlyMode } = require("../middlewares/auth");
 const { getNFTContractAddress } = require("../utils/contracts");
 
 const router = express.Router();
@@ -39,7 +39,7 @@ router.get("/latest-open", async (req, res) => {
   res.status(200).send(batch);
 });
 
-router.post("/create", withRole("admin"), async (req, res) => {
+router.post("/create", readOnlyMode, withRole("admin"), async (req, res) => {
   const neededBodyProps = ["batchName", "batchStatus", "batchStartDate", "batchTelegramLink"];
   if (neededBodyProps.some(prop => req.body[prop] === undefined)) {
     res.status(400).send(`Missing required body property. Required: ${neededBodyProps.join(", ")}`);
@@ -97,7 +97,7 @@ router.post("/create", withRole("admin"), async (req, res) => {
   res.json(batch.data);
 });
 
-router.patch("/update", withRole("admin"), async (req, res) => {
+router.patch("/update", readOnlyMode, withRole("admin"), async (req, res) => {
   const neededBodyProps = ["batchName", "batchStatus", "batchStartDate", "batchTelegramLink"];
   if (neededBodyProps.some(prop => req.body[prop] === undefined)) {
     res.status(400).send(`Missing required body property. Required: ${neededBodyProps.join(", ")}`);

--- a/packages/backend/routes/builders.js
+++ b/packages/backend/routes/builders.js
@@ -2,7 +2,7 @@ const express = require("express");
 const { ethers } = require("ethers");
 const db = require("../services/db/db");
 const { verifySignature } = require("../utils/sign");
-const { withAddress, withRole } = require("../middlewares/auth");
+const { withAddress, withRole, readOnlyMode } = require("../middlewares/auth");
 const { EVENT_TYPES, createEvent } = require("../utils/events");
 const { getEnsFromAddress } = require("../utils/ens");
 
@@ -47,7 +47,7 @@ router.get("/:builderAddress", async (req, res) => {
   res.status(200).json(builder.data);
 });
 
-router.post("/create", withRole("admin"), async (req, res) => {
+router.post("/create", readOnlyMode, withRole("admin"), async (req, res) => {
   const neededBodyProps = ["builderAddress", "builderFunction", "builderRole", "signature"];
   if (neededBodyProps.some(prop => req.body[prop] === undefined)) {
     res.status(400).send(`Missing required body property. Required: ${neededBodyProps.join(", ")}`);
@@ -136,7 +136,7 @@ router.post("/create", withRole("admin"), async (req, res) => {
   res.json(user.data);
 });
 
-router.patch("/update", withRole("admin"), async (req, res) => {
+router.patch("/update", readOnlyMode, withRole("admin"), async (req, res) => {
   const neededBodyProps = ["builderAddress", "builderFunction", "builderRole", "signature"];
   if (neededBodyProps.some(prop => req.body[prop] === undefined)) {
     res.status(400).send(`Missing required body property. Required: ${neededBodyProps.join(", ")}`);
@@ -212,7 +212,7 @@ router.patch("/update", withRole("admin"), async (req, res) => {
   res.json(user.data);
 });
 
-router.post("/update-socials", withAddress, async (req, res) => {
+router.post("/update-socials", readOnlyMode, withAddress, async (req, res) => {
   const { socialLinks, signature } = req.body;
   const address = req.address;
   console.log("POST /builders/update-socials", address, socialLinks);
@@ -233,7 +233,7 @@ router.post("/update-socials", withAddress, async (req, res) => {
   res.status(200).json(updatedUser);
 });
 
-router.post("/set-batch-number", withAddress, async (req, res) => {
+router.post("/set-batch-number", readOnlyMode, withAddress, async (req, res) => {
   const { batch, signature } = req.body;
   const address = req.address;
   console.log("POST /builders/set-batch-number", address, batch);
@@ -260,7 +260,7 @@ router.post("/set-batch-number", withAddress, async (req, res) => {
   res.status(200).json(updatedUser);
 });
 
-router.post("/update-status", withAddress, async (req, res) => {
+router.post("/update-status", readOnlyMode, withAddress, async (req, res) => {
   const { status, signature } = req.body;
   const address = req.address;
   console.log("POST /builders/update-status", address, status);
@@ -290,7 +290,7 @@ router.post("/update-status", withAddress, async (req, res) => {
   res.status(200).json(updatedUser);
 });
 
-router.post("/update-location", withAddress, async (req, res) => {
+router.post("/update-location", readOnlyMode, withAddress, async (req, res) => {
   const { location, signature } = req.body;
   const address = req.address;
   console.log("POST /builders/update-location", address, location);
@@ -312,7 +312,7 @@ router.post("/update-location", withAddress, async (req, res) => {
   res.status(200).json(updatedUser);
 });
 
-router.post("/update-reached-out", withRole("admin"), async (request, response) => {
+router.post("/update-reached-out", readOnlyMode, withRole("admin"), async (request, response) => {
   const { reachedOut, builderAddress, signature } = request.body;
   const address = request.address;
   console.log("POST /builders/update-reached-out", address, reachedOut);
@@ -334,7 +334,7 @@ router.post("/update-reached-out", withRole("admin"), async (request, response) 
   response.status(200).send(updatedUser);
 });
 
-router.post("/update-scholarship", withRole("admin"), async (request, response) => {
+router.post("/update-scholarship", readOnlyMode, withRole("admin"), async (request, response) => {
   const { scholarship, builderAddress, signature } = request.body;
   const address = request.address;
   console.log("POST /builders/update-scholarship", address, scholarship);
@@ -356,7 +356,7 @@ router.post("/update-scholarship", withRole("admin"), async (request, response) 
   response.status(200).send(updatedUser);
 });
 
-router.post("/update-graduated", withRole("admin"), async (request, response) => {
+router.post("/update-graduated", readOnlyMode, withRole("admin"), async (request, response) => {
   const { graduated, reason, builderAddress, signature } = request.body;
   const address = request.address;
   console.log("POST /builders/update-graduated", address, graduated, reason);
@@ -384,7 +384,7 @@ router.post("/update-graduated", withRole("admin"), async (request, response) =>
   response.status(200).send(updatedUser);
 });
 
-router.post("/update-disabled", withRole("admin"), async (request, response) => {
+router.post("/update-disabled", readOnlyMode, withRole("admin"), async (request, response) => {
   const { disabled, builderAddress, signature } = request.body;
   const address = request.address;
   console.log("POST /builders/update-disabled", address, disabled);

--- a/packages/backend/routes/builds.js
+++ b/packages/backend/routes/builds.js
@@ -4,7 +4,7 @@ const db = require("../services/db/db");
 const storage = require("../services/storage/storage");
 const { verifySignature } = require("../utils/sign");
 const { EVENT_TYPES, createEvent } = require("../utils/events");
-const { withRole } = require("../middlewares/auth");
+const { withRole, readOnlyMode } = require("../middlewares/auth");
 
 const router = express.Router();
 
@@ -49,7 +49,7 @@ router.get("/builder/:builderAddress", async (req, res) => {
 /**
  * Create a new build.
  */
-router.post("/", withRole("builder"), async (req, res) => {
+router.post("/", readOnlyMode, withRole("builder"), async (req, res) => {
   console.log("POST /builds");
   const { buildType, buildUrl, videoUrl, demoUrl, desc, image, name, signature, coBuilders } = req.body;
   const address = req.address;
@@ -105,7 +105,7 @@ router.post("/", withRole("builder"), async (req, res) => {
 /**
  * Edit a build.
  */
-router.patch("/:buildId", withRole("builder"), async (req, res) => {
+router.patch("/:buildId", readOnlyMode, withRole("builder"), async (req, res) => {
   const buildId = req.params.buildId;
   const { buildType, buildUrl, demoUrl, videoUrl, desc, image, name, signature, coBuilders } = req.body;
   console.log("EDIT /builds/", buildId);
@@ -176,7 +176,7 @@ router.patch("/:buildId", withRole("builder"), async (req, res) => {
 /**
  * Delete a build.
  */
-router.delete("/:buildId", withRole("builder"), async (req, res) => {
+router.delete("/:buildId", readOnlyMode, withRole("builder"), async (req, res) => {
   const buildId = req.params.buildId;
   console.log("DELETE /builds/", buildId);
 
@@ -222,7 +222,7 @@ router.delete("/:buildId", withRole("builder"), async (req, res) => {
   res.sendStatus(200);
 });
 
-router.post("/upload-img", withRole("builder"), async (req, res) => {
+router.post("/upload-img", readOnlyMode, withRole("builder"), async (req, res) => {
   const form = formidable();
 
   form.parse(req, async (err, fields, files) => {
@@ -246,7 +246,7 @@ router.post("/upload-img", withRole("builder"), async (req, res) => {
 /**
  * Post a like for a build.
  */
-router.post("/like", withRole("builder"), async (req, res) => {
+router.post("/like", readOnlyMode, withRole("builder"), async (req, res) => {
   const { buildId, signature, userAddress } = req.body;
   console.log(`POST /builds/like`);
   const address = req.address;
@@ -290,7 +290,7 @@ router.post("/like", withRole("builder"), async (req, res) => {
 /**
  * Feature / Unfeature a build
  */
-router.patch("/", withRole("admin"), async (req, res) => {
+router.patch("/", readOnlyMode, withRole("admin"), async (req, res) => {
   console.log("PATCH /builds");
   const { buildId, featured, signature, userAddress } = req.body;
   const address = req.address;

--- a/packages/backend/routes/streams.js
+++ b/packages/backend/routes/streams.js
@@ -2,7 +2,7 @@ const express = require("express");
 const ethers = require("ethers");
 const db = require("../services/db/db");
 const { getStreamEvents, updateStreamsForBuilders } = require("../utils/streams");
-const { withRole } = require("../middlewares/auth");
+const { withRole, readOnlyMode } = require("../middlewares/auth");
 const { verifySignature } = require("../utils/sign");
 
 const router = express.Router();
@@ -28,7 +28,7 @@ router.get("/update", async (req, res) => {
 /**
  * Update all builders stream data. (POST)
  */
-router.post("/update", withRole("builder"), async (req, res) => {
+router.post("/update", readOnlyMode, withRole("builder"), async (req, res) => {
   console.log("POST /streams/update");
 
   const { signature } = req.body;
@@ -56,7 +56,7 @@ router.post("/update", withRole("builder"), async (req, res) => {
 /**
  * Update a single builder stream data.
  */
-router.post("/update-single", withRole("builder"), async (req, res) => {
+router.post("/update-single", readOnlyMode, withRole("builder"), async (req, res) => {
   const address = req.address;
   console.log("/streams/update-single", address);
 

--- a/packages/react-app/components/BuilderLocation.jsx
+++ b/packages/react-app/components/BuilderLocation.jsx
@@ -109,7 +109,15 @@ const BuilderLocation = ({ builder }) => {
           )}
         </Box>
         {isMyProfile && (
-          <Button mt={3} size="xs" variant="outline" onClick={onOpen} isFullWidth colorScheme="customBaseColorScheme">
+          <Button
+            mt={3}
+            size="xs"
+            variant="outline"
+            onClick={onOpen}
+            isFullWidth
+            colorScheme="customBaseColorScheme"
+            disabled
+          >
             Update location
           </Button>
         )}

--- a/packages/react-app/components/BuilderProfileCard.jsx
+++ b/packages/react-app/components/BuilderProfileCard.jsx
@@ -313,7 +313,14 @@ const BuilderProfileCard = ({
                 )
               )}
               {isMyProfile && (
-                <Button mb={3} size="xs" variant="outline" onClick={onOpen} colorScheme="customBaseColorScheme">
+                <Button
+                  mb={3}
+                  size="xs"
+                  variant="outline"
+                  onClick={onOpen}
+                  colorScheme="customBaseColorScheme"
+                  disabled
+                >
                   Update socials
                 </Button>
               )}
@@ -356,7 +363,14 @@ const BuilderProfileCard = ({
                 />
               </FormControl>
             ))}
-            <Button colorScheme="blue" onClick={handleUpdateSocials} isLoading={isUpdatingSocials} isFullWidth mt={4}>
+            <Button
+              colorScheme="blue"
+              onClick={handleUpdateSocials}
+              isLoading={isUpdatingSocials}
+              isFullWidth
+              mt={4}
+              disabled
+            >
               Update
             </Button>
           </ModalBody>

--- a/packages/react-app/components/BuilderStatus.jsx
+++ b/packages/react-app/components/BuilderStatus.jsx
@@ -75,7 +75,15 @@ const BuilderStatus = ({ builder }) => {
           )}
         </Box>
         {isMyProfile && (
-          <Button mt={3} size="xs" variant="outline" onClick={onOpen} isFullWidth colorScheme="customBaseColorScheme">
+          <Button
+            mt={3}
+            size="xs"
+            variant="outline"
+            onClick={onOpen}
+            isFullWidth
+            colorScheme="customBaseColorScheme"
+            disabled
+          >
             Update status
           </Button>
         )}

--- a/packages/react-app/pages/builders/[builderAddress].jsx
+++ b/packages/react-app/pages/builders/[builderAddress].jsx
@@ -218,6 +218,22 @@ export default function BuilderProfileView({ serverUrl, mainnetProvider, address
           )}
         </GridItem>
         <GridItem colSpan={{ base: 1, xl: 3 }}>
+          <Flex align="center" justify="center" direction="column" p={4} mb={4} bgColor="yellow.100">
+            <Text fontWeight="bold" mb={2}>
+              ⚠️ Profile Migration ⚠️
+            </Text>
+            <Text textAlign="center" mb={4}>
+              BG profiles have been migrated to SpeedRunEthereum, which will have the canonical profiles where builders
+              can create their onchain portfolio.
+            </Text>
+            <Text>
+              {" "}
+              Check this builder profile{" "}
+              <Link href={`https://speedrunethereum.com/builders/${builder?.id}`} isExternal textDecoration="underline">
+                here
+              </Link>
+            </Text>
+          </Flex>
           {isMyProfile && <BuilderNotifications builder={builder} userProvider={userProvider} onUpdate={refreshData} />}
           <Flex spacing={4} mb={8} direction={{ base: "column-reverse", md: "row" }}>
             {isLoadingBuilder && <BuilderProfileStreamSkeleton />}
@@ -229,7 +245,7 @@ export default function BuilderProfileView({ serverUrl, mainnetProvider, address
             </Heading>
             <Spacer />
             {isMyProfile && (
-              <Button variant="secondary" mb={8} onClick={onOpen}>
+              <Button variant="secondary" mb={8} onClick={onOpen} disabled>
                 Submit New Build
               </Button>
             )}


### PR DESCRIPTION
To merge after https://github.com/BuidlGuidl/SpeedRunEthereum-v2/issues/113

This PR does 3 things:
1. Shows a notification banner
![1](https://github.com/user-attachments/assets/a58c317d-4c09-4ba2-8ff9-1083654fc2d8)

2. Disables UI buttons (for builders)
![2](https://github.com/user-attachments/assets/dbacf68b-72a9-442c-bf77-4ec8a882ceef)

3. Return a 503 error for all the used POST / PATCH routes. I left some of them out that weren't being used. Also left the cohort stuff open just in case.

PS: After some time, we might want to 301 redirect builders' profiles.

Fixes #127
Fixes #128 